### PR TITLE
Publish via emjot concourse ci

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab
+indent_size = 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+* Fork from https://github.com/troykinsella/concourse-ansible-playbook-resource (v2.2.3)
+  and start building/publishing via emjot's concourse CI to emjot's docker hub account
+  (https://hub.docker.com/r/emjotde/concourse-ansible-playbook-resource/).
+  Using a new tagging scheme compared to the previously published images.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM alpine:latest as main
+FROM alpine:3 as main
+
+ARG ANSIBLE_VERSION
 
 RUN set -eux; \
     apk --update add bash openssh-client ruby git ruby-json python3 py3-pip openssl ca-certificates; \
@@ -11,7 +13,7 @@ RUN set -eux; \
       musl-dev \
       cargo; \
     pip3 install --upgrade pip cffi --break-system-packages; \
-    pip3 install ansible boto pywinrm --break-system-packages; \
+    pip3 install "ansible==$ANSIBLE_VERSION" boto pywinrm --break-system-packages; \
     apk del build-dependencies; \
     rm -rf /var/cache/apk/*; \
 # Remove PIP and Cargo cache
@@ -38,5 +40,13 @@ COPY . /resource/
 
 WORKDIR /resource
 RUN rspec
+
+FROM alpine:3 as print_latest_ansible_version
+
+RUN apk --update add --no-cache py3-pip
+
+COPY print_latest_ansible_version.sh /tools/
+WORKDIR /tools
+CMD ["./print_latest_ansible_version.sh"]
 
 FROM main

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+ANSIBLE_VERSION = 10.0.1
+
+.PHONY: build
+build:
+	docker build --pull --target main -t concourse-ansible-playbook-resource \
+		--build-arg ANSIBLE_VERSION="${ANSIBLE_VERSION}" \
+		.
+
+.PHONY: test
+test:
+	docker build --pull --target testing -t concourse-ansible-playbook-resource:testing \
+		--build-arg ANSIBLE_VERSION="${ANSIBLE_VERSION}" \
+		.
+
+.PHONY: print_latest_ansible_version
+print_latest_ansible_version:
+	image=$$(docker build --pull -q --target print_latest_ansible_version .) \
+	&& docker run --rm -it $$image \
+	&& docker image rm $$image >/dev/null

--- a/README.md
+++ b/README.md
@@ -2,12 +2,27 @@
 
 A [Concourse CI](https://concourse-ci.org) resource for running Ansible playbooks.
 
-The resource image contains the latest version of ansible, installed by pip, 
+Fork of https://github.com/troykinsella/concourse-ansible-playbook-resource/.
+(Main reason for this fork is that we want to build it regularly to keep images and ansible versions up to date,
+which does not seem to happen for the original repo as of mid 2024. We will make a best effort to stay up to date
+with the original repo if there are any changes. Note that git version tags will differ.)
+
+Images are published to https://hub.docker.com/r/emjotde/concourse-ansible-playbook-resource/.
+
+The resource image contains the latest version of ansible, installed by pip,
 as of when the image was created. It runs ansible with python 3.
 See the `Dockerfile` for other supplied system and pip packages.
 
-See [Docker Hub](https://cloud.docker.com/repository/docker/troykinsella/concourse-ansible-playbook-resource)
-for tagged image versions available.
+## Tags
+
+A new image is published from master at least once a week (more often if there are new commits on master). There are four kinds of tags being published, three rolling and one static.
+
+Rolling Tags:
+- `latest`: points to the latest image pushed which contains the latest version of Ansible.
+- `ansibleANSIBLE_VERSION` and `ansibleANSIBLE_MAJOR`: These two tags are based on the ansible version (e.g. `ansible10.0.1` and `ansible10`, respectively) and are republished weekly. Only the latest version of ansible is republished. Older versions will become stale.
+
+Static Tag:
+- `REPO_VERSION-ansibleANSIBLE_VERSION-YYYYmmdd`: This tag is a describe_ref string of the git repo commit plus the ansible version plus the date it was published. If you want to stay on a specific ansible/image version then sticking to a particular build will meet your needs.
 
 ## Source Configuration
 
@@ -21,7 +36,7 @@ which are pulled from during `ansible-galaxy install`.
 * `env`: Optional. A list of environment variables to apply.
   Useful for supplying task configuration dependencies like `AWS_ACCESS_KEY_ID`, for example, or specifying
   [ansible configuration](https://docs.ansible.com/ansible/latest/reference_appendices/config.html) options
-  that are unsupported by this resource. Note: Unsupported ansible configurations can also be applied in `ansible.cfg` 
+  that are unsupported by this resource. Note: Unsupported ansible configurations can also be applied in `ansible.cfg`
   in the playbook source.
 * `git_global_config`: Optional. A list of git global configurations to apply (with `git config --global`).
 * `git_https_username`:  Optional. The username for git http/s access.
@@ -29,9 +44,9 @@ which are pulled from during `ansible-galaxy install`.
 * `git_private_key`: Optional. The git ssh private key.
 * `git_skip_ssl_verification`: Optional. Boolean. Default `false`. Don't verify TLS certificates.
 * `user`: Optional. Connect to the remote system with this user.
-* `requirements`: Optional. Default `requirements.yml`. If this file is present in the 
+* `requirements`: Optional. Default `requirements.yml`. If this file is present in the
   playbook source directory, it is used with `ansible-galaxy --install` before running the playbook.
-* `ssh_common_args`: Optional. Specify options to pass to `ssh`. 
+* `ssh_common_args`: Optional. Specify options to pass to `ssh`.
 * `ssh_private_key`: Optional. The `ssh` private key with which to connect to the remote system.
 * `vault_password`: Optional. The value of the `ansible-vault` password.
 * `verbose`: Optional. Specify, `v`, `vv`, etc., to increase the verbosity of the
@@ -69,7 +84,7 @@ resources:
 Execute `ansible-playbook` against a given playbook and inventory file,
 firstly installing dependencies with `ansible-galaxy install -r requirements.yml` if necessary.
 
-Prior to running `ansible-playbook`, if an `ansible.cfg` file is present in the 
+Prior to running `ansible-playbook`, if an `ansible.cfg` file is present in the
 `path` directory, it is sanitized by removing entries for which the equivalent
 command line options are managed by this resource. The result of this sanitization
 can be seen by setting `source.debug: true`.
@@ -82,9 +97,9 @@ Most parameters map directly to `ansible-playbook` options. See the
 * `become`: Optional. Boolean. Default `false`. Run operations as `become` (privilege escalation).
 * `become_user`: Optional. Run operations with this user.
 * `become_method`: Optional. Privilege escalation method to use.
-* `check`: Optional. Boolean. Default `false`. Don't make any changes; 
+* `check`: Optional. Boolean. Default `false`. Don't make any changes;
   instead, try to predict some of the changes that may occur.
-* `diff`: Optional. Boolean. Default `false`. When changing (small) files and 
+* `diff`: Optional. Boolean. Default `false`. When changing (small) files and
   templates, show the differences in those files; works great with `check: true`.
 * `inventory`: Required. The path to the inventory file to use, relative
   to `path`.
@@ -106,12 +121,12 @@ Most parameters map directly to `ansible-playbook` options. See the
 
 As there are a myriad of Ansible modules, each of which having specific system dependencies,
 it becomes untenable for all of them to be supported by this resource Docker image.
-The `setup_commands` parameter of the `put` operation allows the pipeline manager to 
-install system packages known to be depended upon by the particular playbooks being executed. 
-Of course, this flexibility comes at the cost of having to execute the commands upon 
-every `put`. That said, this Concourse resource does intend to supply a set of dependencies out 
-of the box to support the most common or basic Ansible modules. Please open a ticket 
-requesting the addition of a system package if it can be rationalized that it will benefit 
+The `setup_commands` parameter of the `put` operation allows the pipeline manager to
+install system packages known to be depended upon by the particular playbooks being executed.
+Of course, this flexibility comes at the cost of having to execute the commands upon
+every `put`. That said, this Concourse resource does intend to supply a set of dependencies out
+of the box to support the most common or basic Ansible modules. Please open a ticket
+requesting the addition of a system package if it can be rationalized that it will benefit
 a wide variety of use cases.
 
 #### Example
@@ -132,11 +147,27 @@ jobs:
       path: master
 ```
 
-## Testing
+## Development
+
+PRs are welcome!
 
 ```bash
-docker build .
+# Testing:
+make test
+# edit Makefile to change the currently set ANSIBLE_VERSION or run e.g.: make test ANSIBLE_VERSION=10.0.1
+
+# Building:
+make build
+# edit Makefile to change the currently set ANSIBLE_VERSION or run e.g.: make build ANSIBLE_VERSION=10.0.1
+
+# For convenience, get currently latest ansible version available in pip:
+make print_latest_ansible_version
 ```
+
+## Releasing
+
+Update `CHANGELOG.md`: Amend any changes that happened (if that didn't already happen in the PRs/commits)
+and add new version header. Tag with new version and push.
 
 ## License
 

--- a/pipelines/pipeline-pr.yml
+++ b/pipelines/pipeline-pr.yml
@@ -1,0 +1,138 @@
+# Pipeline for PRs
+resource_types:
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: teliaoss/github-pr-resource
+
+resources:
+  - name: repo-pr
+    type: pull-request
+    icon: github
+    source:
+      repository: emjot/concourse-ansible-playbook-resource
+      access_token: ((ci-gh-pr-token))
+      ignore_paths:
+        - "*.md"
+        - "pipelines/*.yml"
+
+jobs:
+  - name: build-and-test
+    plan:
+      - get: repo-pr
+        trigger: true
+      - in_parallel:
+        - put: repo-pr
+          params: { path: repo-pr, context: 'build', status: pending }
+        - put: repo-pr
+          params: { path: repo-pr, context: 'test', status: pending }
+
+      - task: build-for-version
+        privileged: true # oci-build-task must run in a privileged container
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: concourse/oci-build-task
+          inputs:
+            - name: repo-pr
+          outputs:
+            - name: image
+          caches:
+            - path: cache
+          params:
+            CONTEXT: repo-pr/
+            TARGET: print_latest_ansible_version
+            UNPACK_ROOTFS: true
+          run:
+            path: build
+        output_mapping:
+          image: version-image
+      - task: latest-ansible-version
+        image: version-image
+        config:
+          platform: linux
+          outputs:
+            - name: latest-ansible-version
+          run:
+            path: sh
+            args:
+            - -exc
+            - |
+              /tools/print_latest_ansible_version.sh > latest-ansible-version/version
+              ls -la latest-ansible-version
+              cat latest-ansible-version/version | cut -d '.' -f 1 > latest-ansible-version/major
+              cat latest-ansible-version/version
+              cat latest-ansible-version/major
+      - in_parallel:
+        - load_var: ansible-version
+          file: latest-ansible-version/version
+        - load_var: ansible-major
+          file: latest-ansible-version/major
+
+      - task: build-image
+        privileged: true
+        params:
+          BUILD_ARG_ANSIBLE_VERSION: ((.:ansible-version))
+          TARGET: main
+          UNPACK_ROOTFS: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: concourse/oci-build-task
+          inputs:
+            - name: repo-pr
+              path: .
+          outputs:
+            - name: image
+          caches:
+            - path: cache
+          run:
+            path: build
+        on_success:
+          put: repo-pr
+          params: { path: repo-pr, context: 'build', status: success }
+        on_failure:
+          put: repo-pr
+          params: { path: repo-pr, context: 'build', status: failure }
+        on_error:
+          put: repo-pr
+          params: { path: repo-pr, context: 'build', status: error }
+        on_abort:
+          put: repo-pr
+          params: { path: repo-pr, context: 'build', status: error }
+
+      - task: test
+        privileged: true
+        params:
+          BUILD_ARG_ANSIBLE_VERSION: ((.:ansible-version))
+          TARGET: testing
+          UNPACK_ROOTFS: false
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: concourse/oci-build-task
+          inputs:
+            - name: repo-pr
+              path: .
+          caches:
+            - path: cache
+          run:
+            path: build
+        on_success:
+          put: repo-pr
+          params: { path: repo-pr, context: 'test', status: success }
+        on_failure:
+          put: repo-pr
+          params: { path: repo-pr, context: 'test', status: failure }
+        on_error:
+          put: repo-pr
+          params: { path: repo-pr, context: 'test', status: error }
+        on_abort:
+          put: repo-pr
+          params: { path: repo-pr, context: 'test', status: error }

--- a/pipelines/pipeline.yml
+++ b/pipelines/pipeline.yml
@@ -1,0 +1,244 @@
+# This pipeline publishes and keeps the concourse-ansible-playbook-resource image up to date
+resource_types:
+  - name: cogito
+    type: registry-image
+    check_every: 1h
+    source:
+      repository: pix4d/cogito
+
+resources:
+  - name: github-status
+    type: cogito
+    icon: github
+    check_every: 1h
+    source:
+      context_prefix: 'concourse'
+      owner: emjot
+      repo: concourse-ansible-playbook-resource
+      access_token: ((ci-gh-status-token))
+
+  - name: repo
+    type: git
+    icon: git
+    check_every: 30m
+    source:
+      uri: https://github.com/emjot/concourse-ansible-playbook-resource
+      ignore_paths: [pipelines/pipeline.yml, pipelines/pipeline-pr.yml, README.md]
+
+  - name: weekly-rebuild
+    type: time
+    icon: clock
+    source:
+      days:
+        - Thursday
+      start: 3:00 AM
+      stop: 3:30 AM
+      location: Europe/Berlin
+      initial_version: true
+
+  - name: concourse-ansible-playbook-resource
+    icon: docker
+    type: registry-image
+    source:
+      repository: emjotde/concourse-ansible-playbook-resource
+      tag: latest
+      username: ((docker.username))
+      password: ((docker.password))
+
+jobs:
+  - name: build-and-publish
+    plan:
+      - in_parallel:
+        - get: repo
+          trigger: true
+        - get: weekly-rebuild
+          trigger: true
+      - in_parallel:
+        - put: github-status
+          no_get: true
+          inputs: [ repo ]
+          params: { context: 'build', state: pending }
+        - put: github-status
+          no_get: true
+          inputs: [ repo ]
+          params: { context: 'test', state: pending }
+        - put: github-status
+          no_get: true
+          inputs: [ repo ]
+          params: { context: 'publish', state: pending }
+
+      - task: build-for-version
+        privileged: true # oci-build-task must run in a privileged container
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: concourse/oci-build-task
+          inputs:
+            - name: repo
+          outputs:
+            - name: image
+          caches:
+            - path: cache
+          params:
+            CONTEXT: repo/
+            TARGET: print_latest_ansible_version
+            UNPACK_ROOTFS: true
+          run:
+            path: build
+        output_mapping:
+          image: version-image
+      - task: latest-ansible-version
+        image: version-image
+        config:
+          platform: linux
+          outputs:
+            - name: latest-ansible-version
+          run:
+            path: sh
+            args:
+            - -exc
+            - |
+              /tools/print_latest_ansible_version.sh > latest-ansible-version/version
+              ls -la latest-ansible-version
+              cat latest-ansible-version/version | cut -d '.' -f 1 > latest-ansible-version/major
+              cat latest-ansible-version/version
+              cat latest-ansible-version/major
+      - in_parallel:
+        - load_var: ansible-version
+          file: latest-ansible-version/version
+        - load_var: ansible-major
+          file: latest-ansible-version/major
+        - load_var: repo-version
+          file: repo/.git/describe_ref
+
+      - task: build-image
+        privileged: true
+        params:
+          BUILD_ARG_ANSIBLE_VERSION: ((.:ansible-version))
+          TARGET: main
+          UNPACK_ROOTFS: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: concourse/oci-build-task
+          inputs:
+            - name: repo
+              path: .
+          outputs:
+            - name: image
+          caches:
+            - path: cache
+          run:
+            path: build
+        on_success:
+          put: github-status
+          no_get: true
+          inputs: [ repo ]
+          params: { context: 'build', state: success }
+        on_failure:
+          put: github-status
+          no_get: true
+          inputs: [ repo ]
+          params: { context: 'build', state: failure }
+        on_error:
+          put: github-status
+          no_get: true
+          inputs: [ repo ]
+          params: { context: 'build', state: error }
+        on_abort:
+          put: github-status
+          no_get: true
+          inputs: [ repo ]
+          params: { context: 'build', state: error }
+
+      - task: test
+        privileged: true
+        params:
+          BUILD_ARG_ANSIBLE_VERSION: ((.:ansible-version))
+          TARGET: testing
+          UNPACK_ROOTFS: false
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: concourse/oci-build-task
+          inputs:
+            - name: repo
+              path: .
+          caches:
+            - path: cache
+          run:
+            path: build
+        on_success:
+          put: github-status
+          no_get: true
+          inputs: [ repo ]
+          params: { context: 'test', state: success }
+        on_failure:
+          put: github-status
+          no_get: true
+          inputs: [ repo ]
+          params: { context: 'test', state: failure }
+        on_error:
+          put: github-status
+          no_get: true
+          inputs: [ repo ]
+          params: { context: 'test', state: error }
+        on_abort:
+          put: github-status
+          no_get: true
+          inputs: [ repo ]
+          params: { context: 'test', state: error }
+
+      - task: tags
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: busybox
+          params:
+            ANSIBLE_VERSION: ((.:ansible-version))
+            ANSIBLE_MAJOR: ((.:ansible-major))
+            REPO_VERSION: ((.:repo-version))
+          inputs:
+            - name: repo
+          outputs:
+            - name: tags
+          run:
+            path: sh
+            args:
+              - -exc
+              - |
+                echo "ansible${ANSIBLE_MAJOR} ansible${ANSIBLE_VERSION} ${REPO_VERSION}-ansible${ANSIBLE_VERSION}-$(date +%Y%m%d)" > tags/tags
+
+      - put: concourse-ansible-playbook-resource
+        inputs: detect
+        params:
+          image: image/image.tar
+          additional_tags: tags/tags
+        on_success:
+          put: github-status
+          no_get: true
+          inputs: [ repo ]
+          params: { context: 'publish', state: success }
+        on_failure:
+          put: github-status
+          no_get: true
+          inputs: [ repo ]
+          params: { context: 'publish', state: failure }
+        on_error:
+          put: github-status
+          no_get: true
+          inputs: [ repo ]
+          params: { context: 'publish', state: error }
+        on_abort:
+          put: github-status
+          no_get: true
+          inputs: [ repo ]
+          params: { context: 'publish', state: error }

--- a/print_latest_ansible_version.sh
+++ b/print_latest_ansible_version.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# This script can be called inside the built container to get the latest available ansible version via pip.
+# (See Dockerfile print_latest_ansible_version target.)
+
+set -eu
+versions=$(pip index versions ansible 2>/dev/null)
+echo "$versions" | egrep -o '([0-9]+\.){2}[0-9]+' | head -n 1


### PR DESCRIPTION
Publish via emjot's docker account

Main changes:

* Add means to specify (and find out) ansible version for builds/tests
* Add Makefile for convenience
* Add pipelines for emjot's Concourse CI
* Restrict alpine image to 3
* Update README.md, add CHANGELOG.md