### PR TITLE
Remove ruby-json package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3 as main
 ARG ANSIBLE_VERSION
 
 RUN set -eux; \
-    apk --update add bash openssh-client ruby git ruby-json python3 py3-pip openssl ca-certificates; \
+    apk --update add bash openssh-client ruby git python3 py3-pip openssl ca-certificates; \
     apk --update add --virtual \
       build-dependencies \
       build-base \


### PR DESCRIPTION
Alpine 3.22 does not have this package any more and it is not necessary.

* https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/80599
* https://gitlab.alpinelinux.org/alpine/aports/-/issues/16938